### PR TITLE
removed wechat authentication and let user fill in their name manually to prevent keyboard lock

### DIFF
--- a/pages/brief/brief.js
+++ b/pages/brief/brief.js
@@ -6,18 +6,12 @@ var app = getApp()
 Page({
   // build rough data for the page
   data: {
-    userInfo: {},
     loading: false,
   },
   // load data and log success
   onLoad: function () {
     console.log('brief page loaded')
     var that = this
-    app.getUserInfo(function(userInfo){
-      that.setData({
-        userInfo:userInfo
-      })
-    })
   },
   onUnload: function () {
     console.log('brief page unloaded')

--- a/pages/brief/brief.wxml
+++ b/pages/brief/brief.wxml
@@ -16,10 +16,10 @@
     <view class="page-section">
       <view class="page-section-title">1. Your contact details</view>
       <view class="textarea-wrp">
-        <textarea placeholder="name" value="{{userInfo.nickName}}" name="nickName" auto-height />
+        <textarea auto-focus="true" placeholder="Your name" name="nickName" auto-height />
       </view>
       <view class="textarea-wrp">
-        <textarea auto-focus="true" placeholder="email@email.com" name="email" auto-height />
+        <textarea placeholder="email@email.com" name="email" auto-height />
       </view>
       <view class="textarea-wrp">
         <textarea placeholder="+86 185******" name="phone" auto-height />


### PR DESCRIPTION
The keyboard on some android devices prevent the authorization dialog from being clicked. This produces a lock on the UI as neither can be de-activated.

Two solutions:
1) Remove the authorization
2) Prevent the keyboard from showing up automatically

After reviewing the code, wechat authorization is not used to retrieve additional data, or store wechat id into the backend. It is only used for filling out the names field of the form. While saving a step in the form, this introduces a barrier to the user's flow and raises the cost of conversion by demanding  third party access of his data. This additional step seems unnecessary given the field appears and can be filled out regardless if the user gives permission. Therefore best course recommended is solution 1, implemented in this PR.

![image](https://user-images.githubusercontent.com/1525072/35396743-7ea9b28e-0228-11e8-8968-b3ea8ceb49e2.png)
