### PR TITLE
DO NOT MERGE: removed autofocus from brief form to prevent UI locking 

### DIFF
--- a/pages/brief/brief.wxml
+++ b/pages/brief/brief.wxml
@@ -19,7 +19,7 @@
         <textarea placeholder="name" value="{{userInfo.nickName}}" name="nickName" auto-height />
       </view>
       <view class="textarea-wrp">
-        <textarea auto-focus="true" placeholder="email@email.com" name="email" auto-height />
+        <textarea placeholder="email@email.com" name="email" auto-height />
       </view>
       <view class="textarea-wrp">
         <textarea placeholder="+86 185******" name="phone" auto-height />


### PR DESCRIPTION
This PR relates to  #2 

If we decide to keep the wechat authorization, then the alternate solution is to prevent the keyboard from popping up automatically. This is done by removing autofocus on the form input field. 

This can be merged if #2 is rejected
